### PR TITLE
feat: implement async save change dsl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ impl<C> DieselConnection<C> {
     //
     // As this is a blocking mutext, it's recommended to avoid invoking
     // this function from an asynchronous context.
-    pub fn inner(&self) -> std::sync::MutexGuard<'_, C> {
+    fn inner(&self) -> std::sync::MutexGuard<'_, C> {
         self.0.lock().unwrap()
     }
 }


### PR DESCRIPTION
This tries to fix the lifetime problem mentioned in #1.

It does so by basically copying all trait bounds and implementation over from `UpdateAndFetchResults`.
There still some issues:
* since the `Identifiable` derive macro implements for reference, this needs to be implemented by hand
* instead of `Copy`, this requires a `Clone` now which is not ideal. 

It should be possible however to come up with a solution that prevents at least the `Clone`, but the diesel traits are so intertwined that it's not trivial at first glance.