### PR TITLE
Async save changes

### DIFF
--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -15,18 +15,11 @@ pub struct User {
     pub name: String,
 }
 
-use diesel::associations::{HasTable, Identifiable};
-impl HasTable for User {
-    type Table = users::table;
-    fn table() -> Self::Table {
-        users::table
-    }
-}
-impl Identifiable for User {
-    type Id = i32;
-    fn id(self) -> Self::Id {
-        self.id
-    }
+#[derive(AsChangeset, Identifiable, Clone, Copy)]
+#[table_name = "users"]
+pub struct UserUpdate<'a> {
+    pub id: i32,
+    pub name: &'a str,
 }
 
 #[tokio::main]
@@ -65,11 +58,11 @@ async fn main() {
         .unwrap();
 
     // Update via save_changes
-    let user = User {
+    let update = &UserUpdate {
         id: 0,
-        name: "Jim".to_string(),
+        name: "Jim",
     };
-    let _ = user.save_changes_async::<User>(&pool).await.unwrap();
+    let _ = update.save_changes_async::<User>(&pool).await.unwrap();
 
     // Delete
     let _ = diesel::delete(dsl::users)

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -15,7 +15,7 @@ pub struct User {
     pub name: String,
 }
 
-#[derive(AsChangeset, Identifiable, Clone, Copy)]
+#[derive(AsChangeset, Identifiable)]
 #[table_name = "users"]
 pub struct UserUpdate<'a> {
     pub id: i32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ impl<C> DieselConnection<C> {
     //
     // As this is a blocking mutext, it's recommended to avoid invoking
     // this function from an asynchronous context.
-    pub fn inner(&self) -> std::sync::MutexGuard<'_, C> {
+    fn inner(&self) -> std::sync::MutexGuard<'_, C> {
         self.0.lock().unwrap()
     }
 }


### PR DESCRIPTION
Provides a variant of https://github.com/oxidecomputer/async-bb8-diesel/pull/2 which attempts to:

1) Mimic the synchronous interface fairly closely. Using [diesel's examples](https://docs.diesel.rs/diesel/prelude/trait.SaveChangesDsl.html#example), updated the example to derive `AsChangeset` and `Identifiable` directly.

2) Simplify trait bounds, by directly requiring `UpdateAndFetchResults`, rather than implying it indirectly.