### PR TITLE
Add USDT probes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,14 @@ keywords = ["diesel", "r2d2", "pool", "tokio", "async"]
 bb8 = "0.7"
 async-trait = "0.1.51"
 diesel = { git = "https://github.com/diesel-rs/diesel", rev = "a39dd2e", default-features = false, features = [ "r2d2" ] }
+serde = "1"
 thiserror = "1.0"
 tokio = { version = "1.0", default-features = false, features = [ "rt-multi-thread" ] }
+usdt = { path = "../usdt/usdt", version = "0.1.16", default-features = false }
 
 [dev-dependencies]
 diesel = { git = "https://github.com/diesel-rs/diesel", rev = "a39dd2e", features = [ "postgres", "r2d2" ] }
 tokio = { version = "1.0", features = [ "macros"] }
+
+[features]
+usdt-probes = ["usdt/asm"]

--- a/README.md
+++ b/README.md
@@ -86,3 +86,15 @@ constructed.
   when you can block those threads - you can use either of the
   tokio-diesel or bb8-diesel crates, depending on whether or not you
   want access to the asynchronous thread pool.
+
+## USDT probes
+
+This crate contains two DTrace USDT probes:
+
+- `new_connection` is fired whenever the connection manager creates a new
+database connection.
+- `query` is fired for every query to the database, with the raw SQL
+string as an argument
+
+These rely on a nightly toolchain, and so are behind the `usdt-probes`
+feature flag.

--- a/examples/customize_connection.rs
+++ b/examples/customize_connection.rs
@@ -20,6 +20,7 @@ impl bb8::CustomizeConnection<DieselPgConn, ConnectionError> for ConnectionCusto
 
 #[tokio::main]
 async fn main() {
+    usdt::register_probes().unwrap();
     let manager = async_bb8_diesel::ConnectionManager::<PgConnection>::new("localhost:1234");
     let _ = bb8::Pool::builder()
         .connection_customizer(Box::new(ConnectionCustomizer {}))

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -26,6 +26,8 @@ pub struct UserUpdate<'a> {
 async fn main() {
     use users::dsl;
 
+    usdt::register_probes().unwrap();
+
     let manager = async_bb8_diesel::ConnectionManager::<PgConnection>::new("localhost:1234");
     let pool = bb8::Pool::builder().build(manager).await.unwrap();
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -39,7 +39,10 @@ where
     async fn batch_execute_async(&self, query: &str) -> ConnectionResult<()> {
         let diesel_conn = Connection(self.0.clone());
         let query = query.to_string();
-        task::spawn_blocking(move || diesel_conn.inner().batch_execute(&query))
+        task::spawn_blocking(move || {
+                async_bb8_diesel_query!(|| query.as_str());
+                diesel_conn.inner().batch_execute(&query)
+            })
             .await
             .unwrap() // Propagate panics
             .map_err(ConnectionError::from)

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -80,7 +80,11 @@ where
     type Error = ConnectionError;
 
     async fn connect(&self) -> Result<Self::Connection, Self::Error> {
-        self.run_blocking(|m| m.connect())
+        self.run_blocking(|m| {
+            let conn = m.connect();
+            async_bb8_diesel_new_connection!(|| ());
+            conn
+        })
             .await
             .map(Connection::new)
             .map_err(ConnectionError::Checkout)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,17 @@
 //! This is currently implemented against Diesel's synchronous
 //! API, with calls to [`tokio::task::spawn_blocking`] to safely
 //! perform synchronous operations from an asynchronous task.
+#![cfg_attr(feature = "usdt-probes", feature(asm))]
+#[usdt::provider]
+mod async_bb8_diesel {
+    // TODO: It'd be nice to include the database URL here, but
+    // the diesel connection types only store them in private
+    // fields. We can clone it an pass it from the manager to
+    // each connection, but then we incur a cost even when the
+    // probes are disabled, which is not ideal.
+    fn new_connection() {}
+    fn query(sql: String) {}
+}
 
 mod async_traits;
 mod connection;


### PR DESCRIPTION
- Adds the USDT probes `new_connection`, whenever the pool establishes a
  new connection, and `query`, when a query is run. The latter includes
  the entire query string as an argument.
- Adds the `usdt-probes` feature flag, which enables the `usdt` crate's
  actual ASM-based implementation. This requires a nightly compiler. If
  this is _not_ selected (the default) an empty implemenation of the
  USDT probe macros are used instead. This can be built successfully
  wiht a stable toolchain.
- Adds documentation about the probes and their feature flags.