### PR TITLE
Simplify the AsyncConnection trait by implementing transaction using 'run'

### DIFF
--- a/src/async_traits.rs
+++ b/src/async_traits.rs
@@ -34,7 +34,10 @@ where
     async fn transaction<R, Func>(&self, f: Func) -> Result<R, E>
     where
         R: Send + 'static,
-        Func: FnOnce(&mut Conn) -> QueryResult<R> + Send + 'static;
+        Func: FnOnce(&mut Conn) -> QueryResult<R> + Send + 'static,
+    {
+        self.run(|conn| conn.transaction(|c| f(c))).await
+    }
 }
 
 /// An async variant of [`diesel::query_dsl::RunQueryDsl`].

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -64,20 +64,4 @@ where
             .unwrap() // Propagate panics
             .map_err(ConnectionError::from)
     }
-
-    #[inline]
-    async fn transaction<R, Func>(&self, f: Func) -> ConnectionResult<R>
-    where
-        R: Send + 'static,
-        Func: FnOnce(&mut Conn) -> QueryResult<R> + Send + 'static,
-    {
-        let diesel_conn = Connection(self.0.clone());
-        task::spawn_blocking(move || {
-            let mut conn = diesel_conn.inner();
-            conn.transaction(|c| f(c))
-        })
-        .await
-        .unwrap() // Propagate panics
-        .map_err(ConnectionError::from)
-    }
 }

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -142,21 +142,4 @@ where
             .unwrap() // Propagate panics
             .map_err(PoolError::from)
     }
-
-    #[inline]
-    async fn transaction<R, Func>(&self, f: Func) -> PoolResult<R>
-    where
-        R: Send + 'static,
-        Func: FnOnce(&mut Conn) -> QueryResult<R> + Send + 'static,
-    {
-        let self_ = self.clone();
-        let conn = self_.get_owned().await.map_err(PoolError::from)?;
-        task::spawn_blocking(move || {
-            let mut conn = conn.inner();
-            conn.transaction(|c| f(c))
-        })
-        .await
-        .unwrap() // Propagate panics
-        .map_err(PoolError::from)
-    }
 }


### PR DESCRIPTION
This cuts out some redundant code