### PR TITLE
Use generic errors in transactions

### DIFF
--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -1,4 +1,6 @@
-use async_bb8_diesel::{AsyncConnection, AsyncRunQueryDsl, AsyncSaveChangesDsl, ConnectionError, PoolError};
+use async_bb8_diesel::{
+    AsyncConnection, AsyncRunQueryDsl, AsyncSaveChangesDsl, ConnectionError, PoolError,
+};
 use diesel::{pg::PgConnection, prelude::*};
 
 table! {
@@ -22,6 +24,7 @@ pub struct UserUpdate<'a> {
     pub name: &'a str,
 }
 
+// Demonstrates an error which may be returned from transactions.
 #[derive(thiserror::Error, Debug)]
 enum MyError {
     #[error("DB error")]
@@ -98,10 +101,11 @@ async fn main() {
     .await
     .unwrap();
 
-    // Transaction returning errors
-    pool.transaction(|_| {
-        return Err::<(), MyError>(MyError::Other {});
-    })
-    .await
-    .unwrap_err();
+    // Transaction returning custom error types.
+    let _: MyError = pool
+        .transaction(|_| {
+            return Err::<(), MyError>(MyError::Other {});
+        })
+        .await
+        .unwrap_err();
 }

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -1,4 +1,4 @@
-use async_bb8_diesel::{AsyncConnection, AsyncRunQueryDsl, AsyncSaveChangesDsl};
+use async_bb8_diesel::{AsyncConnection, AsyncRunQueryDsl, AsyncSaveChangesDsl, ConnectionError, PoolError};
 use diesel::{pg::PgConnection, prelude::*};
 
 table! {
@@ -20,6 +20,21 @@ pub struct User {
 pub struct UserUpdate<'a> {
     pub id: i32,
     pub name: &'a str,
+}
+
+#[derive(thiserror::Error, Debug)]
+enum MyError {
+    #[error("DB error")]
+    Db(#[from] PoolError),
+
+    #[error("Custom transaction error")]
+    Other,
+}
+
+impl From<diesel::result::Error> for MyError {
+    fn from(error: diesel::result::Error) -> Self {
+        MyError::Db(PoolError::Connection(ConnectionError::Query(error)))
+    }
 }
 
 #[tokio::main]
@@ -78,8 +93,15 @@ async fn main() {
             .values((dsl::id.eq(1), dsl::name.eq("Another Jim")))
             .execute(conn)
             .unwrap();
-        Ok(())
+        Ok::<(), PoolError>(())
     })
     .await
     .unwrap();
+
+    // Transaction returning errors
+    pool.transaction(|_| {
+        return Err::<(), MyError>(MyError::Other {});
+    })
+    .await
+    .unwrap_err();
 }

--- a/src/async_traits.rs
+++ b/src/async_traits.rs
@@ -26,17 +26,34 @@ pub trait AsyncConnection<Conn, ConnErr>: AsyncSimpleConnection<Conn, ConnErr>
 where
     Conn: 'static + DieselConnection,
 {
-    async fn run<R, Func>(&self, f: Func) -> Result<R, ConnErr>
+    /// Runs the function `f` in an context where blocking is safe.
+    ///
+    /// Any error may be propagated through `f`, as long as that
+    /// error type may be constructed from `ConnErr` (as that error
+    /// type may also be generated).
+    //
+    // `run` is usually wrapping a SYNCHRONOUS FUNCTION `f` that
+    // returns a DieselError.
+    //
+    // Except sometimes it wraps the TRANSACTION FUNCTION that
+    // returns an arbitrary error `E`.
+    async fn run<R, E, Func>(&self, f: Func) -> Result<R, E>
     where
         R: Send + 'static,
-        Func: FnOnce(&mut Conn) -> Result<R, DieselError> + Send + 'static;
+        E: From<ConnErr> + Send + 'static,
+        Func: FnOnce(&mut Conn) -> Result<R, E> + Send + 'static;
 
-    async fn transaction<R, Func>(&self, f: Func) -> Result<R, ConnErr>
+    async fn transaction<R, E, Func>(&self, f: Func) -> Result<R, E>
     where
         R: Send + 'static,
-        Func: FnOnce(&mut Conn) -> Result<R, DieselError> + Send + 'static,
+        E: From<DieselError> + From<ConnErr> + Send + 'static,
+        Func: FnOnce(&mut Conn) -> Result<R, E> + Send + 'static,
     {
-        self.run(|conn| conn.transaction(|c| f(c))).await
+        self.run(|conn| {
+            conn.transaction(|c| {
+                f(c)
+            })
+        }).await
     }
 }
 
@@ -78,12 +95,13 @@ where
     T: 'static + Send + RunQueryDsl<Conn>,
     Conn: 'static + DieselConnection,
     AsyncConn: Send + Sync + AsyncConnection<Conn, E>,
+    E: From<DieselError> + Send + 'static,
 {
     async fn execute_async(self, asc: &AsyncConn) -> Result<usize, E>
     where
         Self: ExecuteDsl<Conn>,
     {
-        asc.run(|conn| self.execute(conn)).await
+        asc.run(|conn| self.execute(conn).map_err(E::from)).await
     }
 
     async fn load_async<U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
@@ -91,7 +109,7 @@ where
         U: Send + 'static,
         Self: LoadQuery<Conn, U>,
     {
-        asc.run(|conn| self.load(conn)).await
+        asc.run(|conn| self.load(conn).map_err(E::from)).await
     }
 
     async fn get_result_async<U>(self, asc: &AsyncConn) -> Result<U, E>
@@ -99,7 +117,7 @@ where
         U: Send + 'static,
         Self: LoadQuery<Conn, U>,
     {
-        asc.run(|conn| self.get_result(conn)).await
+        asc.run(|conn| self.get_result(conn).map_err(E::from)).await
     }
 
     async fn get_results_async<U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
@@ -107,7 +125,7 @@ where
         U: Send + 'static,
         Self: LoadQuery<Conn, U>,
     {
-        asc.run(|conn| self.get_results(conn)).await
+        asc.run(|conn| self.get_results(conn).map_err(E::from)).await
     }
 
     async fn first_async<U>(self, asc: &AsyncConn) -> Result<U, E>
@@ -116,7 +134,7 @@ where
         Self: LimitDsl,
         Limit<Self>: LoadQuery<Conn, U>,
     {
-        asc.run(|conn| self.first(conn)).await
+        asc.run(|conn| self.first(conn).map_err(E::from)).await
     }
 }
 
@@ -138,12 +156,13 @@ where
     T: 'static + Send + Sync + diesel::SaveChangesDsl<Conn>,
     Conn: 'static + DieselConnection,
     AsyncConn: Send + Sync + AsyncConnection<Conn, E>,
+    E: 'static + Send + From<DieselError>,
 {
     async fn save_changes_async<Output>(self, asc: &AsyncConn) -> Result<Output, E>
     where
         Conn: diesel::query_dsl::UpdateAndFetchResults<Self, Output>,
         Output: Send + 'static,
     {
-        asc.run(|conn| self.save_changes(conn)).await
+        asc.run(|conn| self.save_changes(conn).map_err(E::from)).await
     }
 }

--- a/src/async_traits.rs
+++ b/src/async_traits.rs
@@ -8,7 +8,7 @@ use diesel::{
         methods::{ExecuteDsl, LimitDsl, LoadQuery},
         RunQueryDsl,
     },
-    QueryResult,
+    result::Error as DieselError,
 };
 
 /// An async variant of [`diesel::connection::SimpleConnection`].
@@ -29,12 +29,12 @@ where
     async fn run<R, Func>(&self, f: Func) -> Result<R, E>
     where
         R: Send + 'static,
-        Func: FnOnce(&mut Conn) -> QueryResult<R> + Send + 'static;
+        Func: FnOnce(&mut Conn) -> Result<R, DieselError> + Send + 'static;
 
     async fn transaction<R, Func>(&self, f: Func) -> Result<R, E>
     where
         R: Send + 'static,
-        Func: FnOnce(&mut Conn) -> QueryResult<R> + Send + 'static,
+        Func: FnOnce(&mut Conn) -> Result<R, DieselError> + Send + 'static,
     {
         self.run(|conn| conn.transaction(|c| f(c))).await
     }

--- a/src/async_traits.rs
+++ b/src/async_traits.rs
@@ -40,7 +40,6 @@ where
     async fn transaction<R, E, Func>(&self, f: Func) -> Result<R, E>
     where
         R: Send + 'static,
-        ConnErr: From<DieselError>,
         E: From<DieselError> + From<ConnErr> + Send + 'static,
         Func: FnOnce(&mut Conn) -> Result<R, E> + Send + 'static,
     {

--- a/src/async_traits.rs
+++ b/src/async_traits.rs
@@ -13,25 +13,25 @@ use diesel::{
 
 /// An async variant of [`diesel::connection::SimpleConnection`].
 #[async_trait]
-pub trait AsyncSimpleConnection<Conn, E>
+pub trait AsyncSimpleConnection<Conn, ConnErr>
 where
     Conn: 'static + SimpleConnection,
 {
-    async fn batch_execute_async(&self, query: &str) -> Result<(), E>;
+    async fn batch_execute_async(&self, query: &str) -> Result<(), ConnErr>;
 }
 
 /// An async variant of [`diesel::connection::Connection`].
 #[async_trait]
-pub trait AsyncConnection<Conn, E>: AsyncSimpleConnection<Conn, E>
+pub trait AsyncConnection<Conn, ConnErr>: AsyncSimpleConnection<Conn, ConnErr>
 where
     Conn: 'static + DieselConnection,
 {
-    async fn run<R, Func>(&self, f: Func) -> Result<R, E>
+    async fn run<R, Func>(&self, f: Func) -> Result<R, ConnErr>
     where
         R: Send + 'static,
         Func: FnOnce(&mut Conn) -> Result<R, DieselError> + Send + 'static;
 
-    async fn transaction<R, Func>(&self, f: Func) -> Result<R, E>
+    async fn transaction<R, Func>(&self, f: Func) -> Result<R, ConnErr>
     where
         R: Send + 'static,
         Func: FnOnce(&mut Conn) -> Result<R, DieselError> + Send + 'static,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -63,8 +63,5 @@ where
         task::spawn_blocking(move || f(&mut *diesel_conn.inner()))
             .await
             .unwrap() // Propagate panics
-//            .map_err(|e| {
-//                ConnectionError::from(e)
-//            })
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,7 +2,8 @@
 
 use crate::{ConnectionError, ConnectionResult};
 use async_trait::async_trait;
-use diesel::{r2d2::R2D2Connection, QueryResult};
+use diesel::r2d2::R2D2Connection;
+use diesel::result::Error as DieselError;
 use std::sync::{Arc, Mutex};
 use tokio::task;
 
@@ -56,7 +57,7 @@ where
     async fn run<R, Func>(&self, f: Func) -> ConnectionResult<R>
     where
         R: Send + 'static,
-        Func: FnOnce(&mut Conn) -> QueryResult<R> + Send + 'static,
+        Func: FnOnce(&mut Conn) -> Result<R, DieselError> + Send + 'static,
     {
         let diesel_conn = Connection(self.0.clone());
         task::spawn_blocking(move || f(&mut *diesel_conn.inner()))

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -54,7 +54,7 @@ where
     Connection<Conn>: crate::AsyncSimpleConnection<Conn, ConnectionError>,
 {
     #[inline]
-    async fn run<R, Func>(&self, f: Func) -> ConnectionResult<R>
+    async fn run<R, Func>(&self, f: Func) -> Result<R, ConnectionError>
     where
         R: Send + 'static,
         Func: FnOnce(&mut Conn) -> Result<R, DieselError> + Send + 'static,

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -4,7 +4,7 @@ use crate::{Connection, ConnectionError, PoolError, PoolResult};
 use async_trait::async_trait;
 use diesel::{
     r2d2::{self, ManageConnection, R2D2Connection},
-    QueryResult,
+    result::Error as DieselError,
 };
 use std::sync::{Arc, Mutex};
 use tokio::task;
@@ -133,7 +133,7 @@ where
     async fn run<R, Func>(&self, f: Func) -> PoolResult<R>
     where
         R: Send + 'static,
-        Func: FnOnce(&mut Conn) -> QueryResult<R> + Send + 'static,
+        Func: FnOnce(&mut Conn) -> Result<R, DieselError> + Send + 'static,
     {
         let self_ = self.clone();
         let conn = self_.get_owned().await.map_err(PoolError::from)?;

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -138,6 +138,5 @@ where
         task::spawn_blocking(move || f(&mut *conn.inner()))
             .await
             .unwrap() // Propagate panics
-//            .map_err(PoolError::from)
     }
 }

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -130,7 +130,7 @@ where
     bb8::Pool<ConnectionManager<Conn>>: crate::AsyncSimpleConnection<Conn, PoolError>,
 {
     #[inline]
-    async fn run<R, Func>(&self, f: Func) -> PoolResult<R>
+    async fn run<R, Func>(&self, f: Func) -> Result<R, PoolError>
     where
         R: Send + 'static,
         Func: FnOnce(&mut Conn) -> Result<R, DieselError> + Send + 'static,


### PR DESCRIPTION
Previously, the `transaction` method of `AsyncConnection` returned a `QueryResult`, which propagates the [Diesel error type](https://docs.diesel.rs/master/diesel/result/enum.Error.html) as an error. For a lot of use-cases, this is sufficient, but it prevents transactions from returning "custom errors". Transactions may perform additional operations, in addition to merely DB-oriented operations, so they may have more featureful errors as well.

This PR updates the generic bounds of errors, allowing any error to be propagated from `transaction`, as long as:
1. It may be constructed `From<DieselError>`. After all, the transaction itself may fail, so the returned error needs to be a superset of this type.
2. It may be constructed `From<ConnErr>` (aka, the "connection-specific" error type). This is necessary because accessing a connection from the underlying pool and issuing a request may also fail, and must be handled within the `transaction` type.

The examples are updated to show how a "custom error" may be returned from transactions with this new implementation.