### PR TITLE
dont merge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["diesel", "r2d2", "pool", "tokio", "async"]
 [dependencies]
 bb8 = "0.7"
 async-trait = "0.1.52"
-diesel = { git = "https://github.com/diesel-rs/diesel", rev = "ce77c382", default-features = false, features = [ "r2d2" ] }
+diesel = { git = "https://github.com/diesel-rs/diesel", rev = "fd723880", default-features = false, features = [ "r2d2" ] }
 thiserror = "1.0"
 tokio = { version = "1.17", default-features = false, features = [ "rt-multi-thread" ] }
 
 [dev-dependencies]
-diesel = { git = "https://github.com/diesel-rs/diesel", rev = "ce77c382", features = [ "postgres", "r2d2" ] }
+diesel = { git = "https://github.com/diesel-rs/diesel", rev = "fd723880", features = [ "postgres", "r2d2" ] }
 tokio = { version = "1.17", features = [ "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["diesel", "r2d2", "pool", "tokio", "async"]
 [dependencies]
 bb8 = "0.7"
 async-trait = "0.1.52"
-diesel = { git = "https://github.com/diesel-rs/diesel", rev = "fd723880", default-features = false, features = [ "r2d2" ] }
+diesel = { git = "https://github.com/diesel-rs/diesel", rev = "6d681420", default-features = false, features = [ "r2d2" ] }
 thiserror = "1.0"
 tokio = { version = "1.17", default-features = false, features = [ "rt-multi-thread" ] }
 
 [dev-dependencies]
-diesel = { git = "https://github.com/diesel-rs/diesel", rev = "fd723880", features = [ "postgres", "r2d2" ] }
+diesel = { git = "https://github.com/diesel-rs/diesel", rev = "6d681420", features = [ "postgres", "r2d2" ] }
 tokio = { version = "1.17", features = [ "macros"] }

--- a/src/async_traits.rs
+++ b/src/async_traits.rs
@@ -57,26 +57,26 @@ where
     where
         Self: ExecuteDsl<Conn>;
 
-    async fn load_async<U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
+    async fn load_async<'a, U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
     where
         U: Send + 'static,
-        Self: LoadQuery<Conn, U>;
+        Self: LoadQuery<'a, Conn, U>;
 
-    async fn get_result_async<U>(self, asc: &AsyncConn) -> Result<U, E>
+    async fn get_result_async<'a, U>(self, asc: &AsyncConn) -> Result<U, E>
     where
         U: Send + 'static,
-        Self: LoadQuery<Conn, U>;
+        Self: LoadQuery<'a, Conn, U>;
 
-    async fn get_results_async<U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
+    async fn get_results_async<'a, U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
     where
         U: Send + 'static,
-        Self: LoadQuery<Conn, U>;
+        Self: LoadQuery<'a, Conn, U>;
 
-    async fn first_async<U>(self, asc: &AsyncConn) -> Result<U, E>
+    async fn first_async<'a, U>(self, asc: &AsyncConn) -> Result<U, E>
     where
         U: Send + 'static,
         Self: LimitDsl,
-        Limit<Self>: LoadQuery<Conn, U>;
+        Limit<Self>: LoadQuery<'a, Conn, U>;
 }
 
 #[async_trait]
@@ -94,36 +94,36 @@ where
         asc.run(|conn| self.execute(conn).map_err(E::from)).await
     }
 
-    async fn load_async<U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
+    async fn load_async<'a, U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
     where
         U: Send + 'static,
-        Self: LoadQuery<Conn, U>,
+        Self: LoadQuery<'a, Conn, U>,
     {
         asc.run(|conn| self.load(conn).map_err(E::from)).await
     }
 
-    async fn get_result_async<U>(self, asc: &AsyncConn) -> Result<U, E>
+    async fn get_result_async<'a, U>(self, asc: &AsyncConn) -> Result<U, E>
     where
         U: Send + 'static,
-        Self: LoadQuery<Conn, U>,
+        Self: LoadQuery<'a, Conn, U>,
     {
         asc.run(|conn| self.get_result(conn).map_err(E::from)).await
     }
 
-    async fn get_results_async<U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
+    async fn get_results_async<'a, U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
     where
         U: Send + 'static,
-        Self: LoadQuery<Conn, U>,
+        Self: LoadQuery<'a, Conn, U>,
     {
         asc.run(|conn| self.get_results(conn).map_err(E::from))
             .await
     }
 
-    async fn first_async<U>(self, asc: &AsyncConn) -> Result<U, E>
+    async fn first_async<'a, U>(self, asc: &AsyncConn) -> Result<U, E>
     where
         U: Send + 'static,
         Self: LimitDsl,
-        Limit<Self>: LoadQuery<Conn, U>,
+        Limit<Self>: LoadQuery<'a, Conn, U>,
     {
         asc.run(|conn| self.first(conn).map_err(E::from)).await
     }

--- a/src/async_traits.rs
+++ b/src/async_traits.rs
@@ -57,26 +57,26 @@ where
     where
         Self: ExecuteDsl<Conn>;
 
-    async fn load_async<'a, U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
+    async fn load_async<U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
     where
         U: Send + 'static,
-        Self: LoadQuery<'a, Conn, U>;
+        Self: LoadQuery<Conn, U>;
 
-    async fn get_result_async<'a, U>(self, asc: &AsyncConn) -> Result<U, E>
+    async fn get_result_async<U>(self, asc: &AsyncConn) -> Result<U, E>
     where
         U: Send + 'static,
-        Self: LoadQuery<'a, Conn, U>;
+        Self: LoadQuery<Conn, U>;
 
-    async fn get_results_async<'a, U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
+    async fn get_results_async<U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
     where
         U: Send + 'static,
-        Self: LoadQuery<'a, Conn, U>;
+        Self: LoadQuery<Conn, U>;
 
-    async fn first_async<'a, U>(self, asc: &AsyncConn) -> Result<U, E>
+    async fn first_async<U>(self, asc: &AsyncConn) -> Result<U, E>
     where
         U: Send + 'static,
         Self: LimitDsl,
-        Limit<Self>: LoadQuery<'a, Conn, U>;
+        Limit<Self>: LoadQuery<Conn, U>;
 }
 
 #[async_trait]
@@ -94,36 +94,36 @@ where
         asc.run(|conn| self.execute(conn).map_err(E::from)).await
     }
 
-    async fn load_async<'a, U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
+    async fn load_async<U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
     where
         U: Send + 'static,
-        Self: LoadQuery<'a, Conn, U>,
+        Self: LoadQuery<Conn, U>,
     {
         asc.run(|conn| self.load(conn).map_err(E::from)).await
     }
 
-    async fn get_result_async<'a, U>(self, asc: &AsyncConn) -> Result<U, E>
+    async fn get_result_async<U>(self, asc: &AsyncConn) -> Result<U, E>
     where
         U: Send + 'static,
-        Self: LoadQuery<'a, Conn, U>,
+        Self: LoadQuery<Conn, U>,
     {
         asc.run(|conn| self.get_result(conn).map_err(E::from)).await
     }
 
-    async fn get_results_async<'a, U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
+    async fn get_results_async<U>(self, asc: &AsyncConn) -> Result<Vec<U>, E>
     where
         U: Send + 'static,
-        Self: LoadQuery<'a, Conn, U>,
+        Self: LoadQuery<Conn, U>,
     {
         asc.run(|conn| self.get_results(conn).map_err(E::from))
             .await
     }
 
-    async fn first_async<'a, U>(self, asc: &AsyncConn) -> Result<U, E>
+    async fn first_async<U>(self, asc: &AsyncConn) -> Result<U, E>
     where
         U: Send + 'static,
         Self: LimitDsl,
-        Limit<Self>: LoadQuery<'a, Conn, U>,
+        Limit<Self>: LoadQuery<Conn, U>,
     {
         asc.run(|conn| self.first(conn).map_err(E::from)).await
     }


### PR DESCRIPTION
Basically I am looking for a fix, in that I can't override locally for the cio the sha you are checking out for diesel and said she has a bug in the 128-column-tables

In the CIO (https://github.com/oxidecomputer/cio) repo, I use
`128-column-tables` and the problem is then when I import this
repo, I get the following error:

```
error: recursion limit reached while expanding `impl_valid_grouping_for_tuple_of_columns!`
   --> /Users/macinatormax/.cargo/git/checkouts/diesel-6e3331fb3b9331ec/ce77c38/diesel/src/type_impls/tuples.rs:478:9
    |
478 | /         impl_valid_grouping_for_tuple_of_columns! {
479 | |             @build
480 | |             start_ts = [$($ST,)*],
481 | |             ts = [$($T,)*],
...   |
488 | |             ],
489 | |         }
    | |_________^
...
561 |   __diesel_for_each_tuple!(tuple_impls);
    |   ------------------------------------- in this macro invocation
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`diesel`)
    = note: this error originates in the macro `impl_valid_grouping_for_tuple_of_columns` (in Nightly builds, run with -Z macro-backtrace for more info)
```

At first I thought it was coming from the fact that you import without that feature flag but that's not it I think that commit just had a bug, anyways its fixed in this one.

But I'm unsure how to fix this without patching you all because I assume you don't want patches for this stuff