### PR TITLE
Add async variant of OptionalExtension

### DIFF
--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -1,5 +1,6 @@
 use async_bb8_diesel::{
-    AsyncConnection, AsyncRunQueryDsl, AsyncSaveChangesDsl, ConnectionError, PoolError,
+    AsyncConnection, AsyncRunQueryDsl, AsyncSaveChangesDsl, ConnectionError, OptionalExtension,
+    PoolError,
 };
 use diesel::{pg::PgConnection, prelude::*};
 
@@ -108,4 +109,13 @@ async fn main() {
         })
         .await
         .unwrap_err();
+
+    // Access the result via OptionalExtension
+    assert!(dsl::users
+        .filter(dsl::id.eq(12345))
+        .first_async::<User>(&pool)
+        .await
+        .optional()
+        .unwrap()
+        .is_none());
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -9,7 +9,7 @@ use tokio::task;
 /// An async-safe analogue of any connection that implements
 /// [`diesel::Connection`].
 ///
-/// These connections are created by [`ConnectionManager`].
+/// These connections are created by [`crate::ConnectionManager`].
 ///
 /// All blocking methods within this type delegate to
 /// [`tokio::task::spawn_blocking`], meaning they won't block

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,8 +25,7 @@ pub enum ConnectionError {
 /// Syntactic sugar around a Result returning an [`PoolError`].
 pub type PoolResult<R> = Result<R, PoolError>;
 
-/// Async variant of
-/// <https://docs.diesel.rs/master/diesel/prelude/trait.OptionalExtension.html>.
+/// Async variant of [diesel::prelude::OptionalExtension].
 pub trait OptionalExtension<T> {
     fn optional(self) -> Result<Option<T>, PoolError>;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub enum ConnectionError {
 /// Syntactic sugar around a Result returning an [`PoolError`].
 pub type PoolResult<R> = Result<R, PoolError>;
 
-/// Async varient of
+/// Async variant of
 /// <https://docs.diesel.rs/master/diesel/prelude/trait.OptionalExtension.html>.
 pub trait OptionalExtension<T> {
     fn optional(self) -> Result<Option<T>, PoolError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,4 @@ pub use async_traits::{
 };
 pub use connection::Connection;
 pub use connection_manager::ConnectionManager;
-pub use error::{ConnectionError, ConnectionResult, PoolError, PoolResult};
+pub use error::{ConnectionError, ConnectionResult, OptionalExtension, PoolError, PoolResult};


### PR DESCRIPTION
This is functionally identical to https://docs.diesel.rs/master/diesel/prelude/trait.OptionalExtension.html, but operates on the `PoolError` instead of a `Result<T, diesel::result::Error>`.

`async-bb8-diesel` may propagate more errors than merely `diesel::result::Error`, and as a consequence, cannot simply return a [QueryResult](https://docs.diesel.rs/master/diesel/prelude/type.QueryResult.html) like the synchronous counterparts from [RunQueryDsl](https://docs.diesel.rs/master/diesel/prelude/trait.RunQueryDsl.html).

However, this new trait provides the same utility as the `OptionalExtension`.