### PR TITLE
Implement transactions operating on async closures.

### DIFF
--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -110,6 +110,18 @@ async fn main() {
         .await
         .unwrap_err();
 
+    // Asynchronous transaction.
+    pool.transaction_async(|conn| async move {
+        diesel::update(dsl::users)
+            .filter(dsl::id.eq(0))
+            .set(dsl::name.eq("Let's change the name again"))
+            .execute_async(&conn)
+            .await
+            .map_err(|e| PoolError::Connection(e))
+    })
+    .await
+    .unwrap();
+
     // Access the result via OptionalExtension
     assert!(dsl::users
         .filter(dsl::id.eq(12345))

--- a/src/async_traits.rs
+++ b/src/async_traits.rs
@@ -1,8 +1,9 @@
 //! Async versions of traits for issuing Diesel queries.
 
+use crate::connection::Connection as SingleConnection;
 use async_trait::async_trait;
 use diesel::{
-    connection::{Connection as DieselConnection, SimpleConnection},
+    connection::{Connection as DieselConnection, SimpleConnection, TransactionManager},
     dsl::Limit,
     query_dsl::{
         methods::{ExecuteDsl, LimitDsl, LoadQuery},
@@ -10,6 +11,10 @@ use diesel::{
     },
     result::Error as DieselError,
 };
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::MutexGuard;
+use tokio::task::spawn_blocking;
 
 /// An async variant of [`diesel::connection::SimpleConnection`].
 #[async_trait]
@@ -25,7 +30,18 @@ where
 pub trait AsyncConnection<Conn, ConnErr>: AsyncSimpleConnection<Conn, ConnErr>
 where
     Conn: 'static + DieselConnection,
+    ConnErr: From<DieselError> + Send + 'static,
+    Self: Send,
 {
+    type OwnedConnection: Sync + Send + 'static;
+
+    #[doc(hidden)]
+    async fn get_owned_connection(&self) -> Result<Self::OwnedConnection, ConnErr>;
+    #[doc(hidden)]
+    fn as_sync_conn(owned: &Self::OwnedConnection) -> MutexGuard<'_, Conn>;
+    #[doc(hidden)]
+    fn as_async_conn(owned: &Self::OwnedConnection) -> &SingleConnection<Conn>;
+
     /// Runs the function `f` in an context where blocking is safe.
     ///
     /// Any error may be propagated through `f`, as long as that
@@ -35,7 +51,41 @@ where
     where
         R: Send + 'static,
         E: From<ConnErr> + Send + 'static,
-        Func: FnOnce(&mut Conn) -> Result<R, E> + Send + 'static;
+        Func: FnOnce(&mut Conn) -> Result<R, E> + Send + 'static,
+    {
+        let connection = self.get_owned_connection().await?;
+        Self::run_with_connection(connection, f).await
+    }
+
+    #[doc(hidden)]
+    async fn run_with_connection<R, E, Func>(
+        connection: Self::OwnedConnection,
+        f: Func,
+    ) -> Result<R, E>
+    where
+        R: Send + 'static,
+        E: From<ConnErr> + Send + 'static,
+        Func: FnOnce(&mut Conn) -> Result<R, E> + Send + 'static,
+    {
+        spawn_blocking(move || f(&mut *Self::as_sync_conn(&connection)))
+            .await
+            .unwrap() // Propagate panics
+    }
+
+    #[doc(hidden)]
+    async fn run_with_shared_connection<R, E, Func>(
+        connection: Arc<Self::OwnedConnection>,
+        f: Func,
+    ) -> Result<R, E>
+    where
+        R: Send + 'static,
+        E: From<ConnErr> + Send + 'static,
+        Func: FnOnce(&mut Conn) -> Result<R, E> + Send + 'static,
+    {
+        spawn_blocking(move || f(&mut *Self::as_sync_conn(&connection)))
+            .await
+            .unwrap() // Propagate panics
+    }
 
     async fn transaction<R, E, Func>(&self, f: Func) -> Result<R, E>
     where
@@ -44,6 +94,61 @@ where
         Func: FnOnce(&mut Conn) -> Result<R, E> + Send + 'static,
     {
         self.run(|conn| conn.transaction(|c| f(c))).await
+    }
+
+    async fn transaction_async<R, E, Func, Fut, 'a>(&'a self, f: Func) -> Result<R, E>
+    where
+        R: Send + 'static,
+        E: From<DieselError> + From<ConnErr> + Send,
+        Fut: Future<Output = Result<R, E>> + Send,
+        Func: FnOnce(SingleConnection<Conn>) -> Fut + Send,
+    {
+        // Check out a connection once, and use it for the duration of the
+        // operation.
+        let conn = Arc::new(self.get_owned_connection().await?);
+
+        // This function mimics the implementation of:
+        // https://docs.diesel.rs/master/diesel/connection/trait.TransactionManager.html#method.transaction
+        //
+        // However, it modifies all callsites to instead issue
+        // known-to-be-synchronous operations from an asynchronous context.
+        Self::run_with_shared_connection(conn.clone(), |conn| {
+            Conn::TransactionManager::begin_transaction(conn).map_err(ConnErr::from)
+        })
+        .await?;
+
+        // TODO: The ideal interface would pass the "async_conn" object to the
+        // underlying function "f" by reference.
+        //
+        // This would prevent the user-supplied closure + future from using the
+        // connection *beyond* the duration of the transaction, which would be
+        // bad.
+        //
+        // However, I'm struggling to get these lifetimes to work properly. If
+        // you can figure out a way to convince that the reference lives long
+        // enough to be referenceable by a Future, but short enough that we can
+        // guarantee it doesn't live persist after this function returns, feel
+        // free to make that change.
+        let async_conn = SingleConnection(Self::as_async_conn(&conn).0.clone());
+        match f(async_conn).await {
+            Ok(value) => {
+                Self::run_with_shared_connection(conn.clone(), |conn| {
+                    Conn::TransactionManager::commit_transaction(conn).map_err(ConnErr::from)
+                })
+                .await?;
+                Ok(value)
+            }
+            Err(user_error) => {
+                match Self::run_with_shared_connection(conn.clone(), |conn| {
+                    Conn::TransactionManager::rollback_transaction(conn).map_err(ConnErr::from)
+                })
+                .await
+                {
+                    Ok(()) => Err(user_error),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes: https://github.com/oxidecomputer/async-bb8-diesel/issues/32

This provides an additional method to the `AsyncConnection` trait: `transaction_async`.

`transaction_async` acts similarly to `transaction`, but instead of operating on a closure (which expects to be synchronous), `transaction_async` can operate on an asynchronous block.