### PR TITLE
clarify connection-related error messages

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-10.15 ]
+        os: [ ubuntu-latest, macos-12 ]
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@f095bcc56b7c2baf48f3ac70d6d6782f4f553222

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -80,7 +80,7 @@ where
         self.run_blocking(|m| m.connect())
             .await
             .map(Connection::new)
-            .map_err(ConnectionError::Checkout)
+            .map_err(ConnectionError::Connection)
     }
 
     async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,8 +15,8 @@ pub type ConnectionResult<R> = Result<R, ConnectionError>;
 /// Errors returned directly from Connection.
 #[derive(Error, Debug)]
 pub enum ConnectionError {
-    #[error("Failed to checkout a connection: {0}")]
-    Checkout(#[from] diesel::r2d2::Error),
+    #[error("Connection error: {0}")]
+    Connection(#[from] diesel::r2d2::Error),
 
     #[error("Failed to issue a query: {0}")]
     Query(#[from] DieselError),


### PR DESCRIPTION
While doing oxidecomputer/omicron#3232 I found the error message for connection-related errors always says that it was checking out a connection, but that isn't necessarily true.  As far as I can tell, this variant is used in two places:

- during actual connection establishment, when that fails: https://github.com/oxidecomputer/async-bb8-diesel/blob/master/src/connection_manager.rs#L83
- when the pool actively checks whether a connection is valid: https://github.com/oxidecomputer/async-bb8-diesel/blob/master/src/connection_manager.rs#L89

I'm changing the variant name and error message here to just say that this was a connection-related error.