### PR TITLE
Remove execution for connection manager

### DIFF
--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -27,17 +27,9 @@ use std::sync::{Arc, Mutex};
 ///     let mgr = async_bb8_diesel::ConnectionManager::<PgConnection>::new("localhost:1234");
 ///     let pool = bb8::Pool::builder().build(mgr).await.unwrap();
 ///
-///     // You can acquire connections to the pool manually...
 ///     diesel::insert_into(dsl::users)
 ///         .values(dsl::id.eq(1337))
 ///         .execute_async(&*pool.get().await.unwrap())
-///         .await
-///         .unwrap();
-///
-///     // ... Or just issue them to the pool directly.
-///     diesel::insert_into(dsl::users)
-///         .values(dsl::id.eq(1337))
-///         .execute_async(&pool)
 ///         .await
 ///         .unwrap();
 /// }

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -1,10 +1,9 @@
 //! An async-safe connection pool for Diesel.
 
-use crate::{Connection, ConnectionError, PoolError, PoolResult};
+use crate::{Connection, ConnectionError};
 use async_trait::async_trait;
 use diesel::r2d2::{self, ManageConnection, R2D2Connection};
-use std::sync::{Arc, Mutex, MutexGuard};
-use tokio::task;
+use std::sync::{Arc, Mutex};
 
 /// A connection manager which implements [`bb8::ManageConnection`] to
 /// integrate with bb8.
@@ -97,44 +96,5 @@ where
         // inner method without blocking as this method is not async, but `bb8`
         // indicates that this method is not mandatory.
         false
-    }
-}
-
-#[async_trait]
-impl<Conn> crate::AsyncSimpleConnection<Conn, PoolError> for bb8::Pool<ConnectionManager<Conn>>
-where
-    Conn: 'static + R2D2Connection,
-{
-    #[inline]
-    async fn batch_execute_async(&self, query: &str) -> PoolResult<()> {
-        let self_ = self.clone();
-        let query = query.to_string();
-        let conn = self_.get_owned().await.map_err(PoolError::from)?;
-        task::spawn_blocking(move || conn.inner().batch_execute(&query))
-            .await
-            .unwrap() // Propagate panics
-            .map_err(PoolError::from)
-    }
-}
-
-#[async_trait]
-impl<Conn> crate::AsyncConnection<Conn, PoolError> for bb8::Pool<ConnectionManager<Conn>>
-where
-    Conn: 'static + R2D2Connection,
-    bb8::Pool<ConnectionManager<Conn>>: crate::AsyncSimpleConnection<Conn, PoolError>,
-{
-    type OwnedConnection = bb8::PooledConnection<'static, ConnectionManager<Conn>>;
-
-    async fn get_owned_connection(&self) -> Result<Self::OwnedConnection, PoolError> {
-        let self_ = self.clone();
-        Ok(self_.get_owned().await.map_err(PoolError::from)?)
-    }
-
-    fn as_sync_conn(owned: &Self::OwnedConnection) -> MutexGuard<'_, Conn> {
-        owned.inner()
-    }
-
-    fn as_async_conn(owned: &Self::OwnedConnection) -> &crate::connection::Connection<Conn> {
-        &*owned
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,25 +26,11 @@ pub enum ConnectionError {
 pub type PoolResult<R> = Result<R, PoolError>;
 
 /// Async variant of [diesel::prelude::OptionalExtension].
-pub trait OptionalExtension<T, E> {
-    fn optional(self) -> Result<Option<T>, E>;
+pub trait OptionalExtension<T> {
+    fn optional(self) -> Result<Option<T>, ConnectionError>;
 }
 
-impl<T> OptionalExtension<T, PoolError> for Result<T, PoolError> {
-    fn optional(self) -> Result<Option<T>, PoolError> {
-        let self_as_query_result: diesel::QueryResult<T> = match self {
-            Ok(value) => Ok(value),
-            Err(PoolError::Connection(ConnectionError::Query(error_kind))) => Err(error_kind),
-            Err(e) => return Err(e),
-        };
-
-        self_as_query_result
-            .optional()
-            .map_err(|e| PoolError::Connection(ConnectionError::Query(e)))
-    }
-}
-
-impl<T> OptionalExtension<T, ConnectionError> for Result<T, ConnectionError> {
+impl<T> OptionalExtension<T> for Result<T, ConnectionError> {
     fn optional(self) -> Result<Option<T>, ConnectionError> {
         let self_as_query_result: diesel::QueryResult<T> = match self {
             Ok(value) => Ok(value),


### PR DESCRIPTION
- In an attempt to simplify errors, reduce polymorphism, and reduce build times, this PR removes support for "pool-based queries", instead preferring that clients check out connections before sending queries to the underlying pool.

## Previously

- `AsyncConnection` was implemented for both connections and for the pool itself. This meant the query execution functions (i.e., `execute_async(...)`) could act on either a pool or a connection.
- Although this was flexible, it was arguably **too** flexible -- clients would need to deal with `ConnectionError` errors from queries to connections, or `PoolError` errors from queries to pools (which is basically `ConnectionError` + Any error from checking out the connection).

## Now

- `AsyncConnection` is implemented for connections, not pools. This should unify error handling for callers, and hopefully make the access to individual DB connections a little more obvious.

Part of https://github.com/oxidecomputer/omicron/issues/4132