### PR TITLE
Deprecate synchronous transactions

### DIFF
--- a/src/async_traits.rs
+++ b/src/async_traits.rs
@@ -82,15 +82,6 @@ where
             .unwrap() // Propagate panics
     }
 
-    async fn transaction<R, E, Func>(&self, f: Func) -> Result<R, E>
-    where
-        R: Send + 'static,
-        E: From<DieselError> + Send + 'static,
-        Func: FnOnce(&mut Conn) -> Result<R, E> + Send + 'static,
-    {
-        self.run(|conn| conn.transaction(|c| f(c))).await
-    }
-
     async fn transaction_async<R, E, Func, Fut, 'a>(&'a self, f: Func) -> Result<R, E>
     where
         R: Send + 'static,


### PR DESCRIPTION
Before this PR, async-bb8-diesel exposed APIs to issue transactions with "synchronous" and "asynchronous" closures, even though the transaction as a whole was asynchronous.

This PR removes the ability to issue synchronous transactions, as all clients within the Omicron repository are using the asynchronous variant now anyway.