### PR TITLE
[RFC] handle runtime shutdowns while tasks are being spawned

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,6 @@ pub use async_traits::{
 };
 pub use connection::Connection;
 pub use connection_manager::ConnectionManager;
-pub use error::{ConnectionError, ConnectionResult, OptionalExtension, PoolError, PoolResult};
+pub use error::{
+    ConnectionError, ConnectionResult, OptionalExtension, PoolError, PoolResult, RunError,
+};


### PR DESCRIPTION
If a runtime has been marked as shutting down before `spawn_blocking` is
called, or before the blocking task is first scheduled, the `JoinHandle` will
return a cancellation error. Currently, this panics, which tends to manifest as
test failures (e.g. https://github.com/oxidecomputer/omicron/issues/6505)

Instead, add a `RunError` wrapper that captures the cancellation situation.
Callers might choose to bubble this error up or to squelch it -- unfortunately,
we can't make this decision.

I haven't written tests yet but I should be able to if this looks reasonble.

The API surface here is really unfortunate, but I can't see a better way to do
this than to propagate errors up the stack.
