### PR TITLE
Update to supported macos runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,11 +31,20 @@ jobs:
     - name: Cargo check
       run: cargo check --no-default-features
 
-  build-and-test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-12 ]
+  build-and-test-macos-14:
+    runs-on: macos-14
+    steps:
+    # actions/checkout@v2
+    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+    - name: Link libpq
+      run: brew link --force libpq
+    - name: Build
+      run: cargo build --tests --verbose
+    - name: Run tests
+      run: cargo test --verbose
+
+  build-and-test-ubuntu:
+    runs-on: ubuntu-latest
     steps:
     # actions/checkout@v2
     - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938


### PR DESCRIPTION
macos-12 is no longer supported as a runner target on GitHub. This updates the workflow to target macos-14 and fixes a link failure that occurs by default.