### PR TITLE
Bump diesel and bb8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ cockroach = []
 default = [ "cockroach" ]
 
 [dependencies]
-bb8 = "0.8"
+bb8 = "0.9"
 async-trait = "0.1.89"
-diesel = { version = "2.3.4", default-features = false, features = [ "r2d2" ] }
+diesel = { version = "2.3.5", default-features = false, features = [ "r2d2" ] }
 futures = "0.3"
 thiserror = "2.0"
 tokio = { version = "1.32", default-features = false, features = [ "rt-multi-thread" ] }
@@ -24,7 +24,7 @@ tokio = { version = "1.32", default-features = false, features = [ "rt-multi-thr
 [dev-dependencies]
 anyhow = "1.0"
 crdb-harness = "0.0.2"
-diesel = { version = "2.3.4", features = [ "postgres", "r2d2" ] }
+diesel = { version = "2.3.5", features = [ "postgres", "r2d2" ] }
 libc = "0.2.178"
 tempfile = "3.8"
 tokio = { version = "1.32", features = [ "macros", "fs", "process" ] }

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -1,7 +1,6 @@
 //! An async-safe connection pool for Diesel.
 
 use crate::{Connection, ConnectionError};
-use async_trait::async_trait;
 use diesel::r2d2::{self, ManageConnection, R2D2Connection};
 use std::sync::{Arc, Mutex};
 
@@ -59,7 +58,6 @@ impl<T: Send + 'static> ConnectionManager<T> {
     }
 }
 
-#[async_trait]
 impl<T> bb8::ManageConnection for ConnectionManager<T>
 where
     T: R2D2Connection + Send + 'static,


### PR DESCRIPTION
* bumped diesel version
* update bb8 to be inline with v-api
* fix CustomizeConnection example for bb8 0.9
* Use explicit lifetimes with Pin<Box<dyn Future>> instead of async_trait macro to match bb8 0.9's trait signature.

a little bit of work had to be done to align the code with bb8's changes in trait definitions. Unit tests look good. I don't have a full grasp of how far reaching this change will be. This fixes #88 and does the same things that #82 did. 