### PR TITLE
0.3.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async-bb8-diesel"
 description = "async bb8 connection manager for Diesel"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Sean Klein <sean@oxide.computer>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Mostly updating dependencies:

- bb8 0.8 -> 0.9
- diesel 2.1.6 -> 2.3.5
- async-trait 0.1.80 -> 0.1.89
- thiserror 1.0 -> 2.0